### PR TITLE
allow schema:domain/rangeIncludes and rdfs:Class

### DIFF
--- a/src/main/webapp/extraction.xsl
+++ b/src/main/webapp/extraction.xsl
@@ -19,6 +19,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" version="2.0"
     xmlns:dc="http://purl.org/dc/elements/1.1/"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:schema="http://schema.org/"
     xmlns:swrl="http://www.w3.org/2003/11/swrl#"
     xmlns:owl2xml="http://www.w3.org/2006/12/owl2-xml#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -343,7 +344,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     <xsl:template match="element()" mode="ontology" />
     <xsl:template match="element()|text()[normalize-space() = '']" />
     
-    <xsl:template match="owl:Class">
+    <xsl:template match="owl:Class|rdfs:Class">
         <div id="{generate-id()}" class="entity">
             <xsl:call-template name="get.entity.name">
                 <xsl:with-param name="toc" select="'classes'" tunnel="yes" as="xs:string" />
@@ -382,7 +383,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         </div>
     </xsl:template>
     
-    <xsl:template match="rdfs:range | rdfs:domain">
+    <xsl:template match="rdfs:range|schema:rangeIncludes | rdfs:domain|schema:domainIncludes">
         <dd>
             <xsl:apply-templates select="@*:resource | element()">
                 <xsl:with-param name="type" select="'class'" as="xs:string" tunnel="yes" />
@@ -590,7 +591,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         </xsl:choose>
     </xsl:function>
     
-    <xsl:template match="owl:Class[not(parent::rdf:RDF)] | rdfs:Datatype[not(parent::rdf:RDF)] | owl:DataRange[not(parent::rdf:RDF)]">
+    <xsl:template match="owl:Class[not(parent::rdf:RDF)] | rdfs:Class[not(parent::rdf:RDF)] | rdfs:Datatype[not(parent::rdf:RDF)] | owl:DataRange[not(parent::rdf:RDF)]">
         <xsl:apply-templates />
     </xsl:template>
     
@@ -687,7 +688,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         <xsl:apply-templates select="owl:onClass" />
     </xsl:template>
     
-    <xsl:template match="/rdf:RDF/owl:Class[empty(@*:about | @*:ID) and exists(rdfs:subClassOf)]">
+    <xsl:template match="/rdf:RDF/owl:Class [empty(@*:about | @*:ID) and exists(rdfs:subClassOf)] |
+                         /rdf:RDF/rdfs:Class[empty(@*:about | @*:ID) and exists(rdfs:subClassOf)]">
         <div id="{generate-id()}" class="entity">
             <h3><xsl:value-of select="f:getDescriptionLabel('subclassdefinition')" /><xsl:text> </xsl:text><xsl:call-template name="get.backlink" /></h3>
             <p>
@@ -702,7 +704,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         </div>
     </xsl:template>
     
-    <xsl:template match="/rdf:RDF/owl:Class[empty(@*:about | @*:ID) and exists(owl:equivalentClass)]">
+    <xsl:template match="/rdf:RDF/owl:Class [empty(@*:about | @*:ID) and exists(owl:equivalentClass)] |
+                         /rdf:RDF/rdfs:Class[empty(@*:about | @*:ID) and exists(owl:equivalentClass)]">
         <div id="{generate-id()}" class="entity">
             <h3><xsl:value-of select="f:getDescriptionLabel('equivalentdefinition')" /><xsl:text> </xsl:text><xsl:call-template name="get.backlink" /></h3>
             <p>
@@ -1077,13 +1080,21 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     <xsl:template name="get.class.superclasses">
         <xsl:if test="exists(rdfs:subClassOf)">
             <dt><xsl:value-of select="f:getDescriptionLabel('hassuperclasses')" /></dt>
-            <xsl:apply-templates select="rdfs:subClassOf" />
+            <dd>
+                <xsl:for-each select="rdfs:subClassOf/(@*:resource|(owl:Class|rdfs:Class)/@*:about)">
+                    <xsl:sort select="f:getLabel(.)" data-type="text" order="ascending" />
+                    <xsl:apply-templates select="." />
+                    <xsl:if test="position() != last()">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                </xsl:for-each>
+            </dd>
         </xsl:if>
     </xsl:template>
     
     <xsl:template name="get.class.subclasses">
         <xsl:variable name="about" select="@*:about|@*:ID" as="xs:string" />
-        <xsl:variable name="sub-classes" as="attribute()*" select="/rdf:RDF/owl:Class[some $res in rdfs:subClassOf/@*:resource satisfies $res = $about]/(@*:about|@*:ID)" />
+        <xsl:variable name="sub-classes" as="attribute()*" select="/rdf:RDF/(owl:Class|rdfs:Class)[some $res in rdfs:subClassOf/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $about]/(@*:about|@*:ID)" />
         <xsl:if test="exists($sub-classes)">
             <dt><xsl:value-of select="f:getDescriptionLabel('hassubclasses')" /></dt>
             <dd>
@@ -1100,7 +1111,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:template name="get.class.indomain">
         <xsl:variable name="about" select="@*:about|@*:ID" as="xs:string" />
-        <xsl:variable name="properties" as="attribute()*" select="/rdf:RDF/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in rdfs:domain/@*:resource satisfies $res = $about]/(@*:about|@*:ID)" />
+        <xsl:variable name="properties" as="attribute()*" select="/rdf:RDF/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in (rdfs:domain|schema:domainIncludes)/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $about]/(@*:about|@*:ID)" />
         <xsl:if test="exists($properties)">
             <dt><xsl:value-of select="f:getDescriptionLabel('isindomainof')" /></dt>
             <dd>
@@ -1119,7 +1130,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:template name="get.class.inrange">
         <xsl:variable name="about" select="(@*:about|@*:ID)" as="xs:string" />
-        <xsl:variable name="properties" as="attribute()*" select="/rdf:RDF/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in rdfs:range/@*:resource satisfies $res = $about]/(@*:about|@*:ID)" />
+        <xsl:variable name="properties" as="attribute()*" select="/rdf:RDF/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in (rdfs:range|schema:rangeIncludes)/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $about]/(@*:about|@*:ID)" />
         <xsl:if test="exists($properties)">
             <dt><xsl:value-of select="f:getDescriptionLabel('isinrangeof')" /></dt>
             <dd>
@@ -1138,7 +1149,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:template name="get.class.members">
         <xsl:variable name="about" select="(@*:about|@*:ID)" as="xs:string" />
-        <xsl:variable name="members" as="attribute()*" select="/rdf:RDF/owl:NamedIndividual[some $res in rdf:type/@*:resource satisfies $res = $about]/(@*:about|@*:ID)" />
+        <xsl:variable name="members" as="attribute()*" select="/rdf:RDF/owl:NamedIndividual[some $res in rdf:type/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $about]/(@*:about|@*:ID)" />
         <xsl:if test="exists($members)">
             <dt><xsl:value-of select="f:getDescriptionLabel('hasmembers')" /></dt>
             <dd>
@@ -1156,7 +1167,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     </xsl:template>
     
     <xsl:template name="get.property.description">
-        <xsl:if test="exists(rdfs:subPropertyOf | rdfs:domain | rdfs:range | owl:propertyChainAxiom) or f:hasSubproperties(.) or f:hasInverseOf(.) or f:hasDisjoints(.) or f:hasEquivalent(.) or f:hasSameAs(.) or f:hasPunning(.)">
+        <xsl:if test="exists(rdfs:subPropertyOf | (rdfs:domain|schema:domainIncludes) | (rdfs:range|schema:rangeIncludes) | owl:propertyChainAxiom) or f:hasSubproperties(.) or f:hasInverseOf(.) or f:hasDisjoints(.) or f:hasEquivalent(.) or f:hasSameAs(.) or f:hasPunning(.)">
             <div class="description">
                 <xsl:call-template name="get.characteristics" />
                 <dl>
@@ -1221,14 +1232,22 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     <xsl:template name="get.property.superproperty">
         <xsl:if test="exists(rdfs:subPropertyOf)">
             <dt><xsl:value-of select="f:getDescriptionLabel('hassuperproperties')" /></dt>
-            <xsl:apply-templates select="rdfs:subPropertyOf" />
+            <dd>
+                <xsl:for-each select="rdfs:subPropertyOf/(@*:resource|(rdf:Property|owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)/@*:about)">
+                    <xsl:sort select="f:getLabel(.)" data-type="text" order="ascending" />
+                    <xsl:apply-templates select="." />
+                    <xsl:if test="position() != last()">
+                        <xsl:text>, </xsl:text>
+                    </xsl:if>
+                </xsl:for-each>
+            </dd>
         </xsl:if>
     </xsl:template>
     
     <xsl:template name="get.property.subproperty">
         <xsl:variable name="type" select="if (self::owl:AnnotationProperty) then 'annotation' else 'property'" as="xs:string" />
         <xsl:variable name="about" select="(@*:about|@*:ID)" as="xs:string" />
-        <xsl:variable name="sub-properties" as="attribute()*" select="/rdf:RDF/(if ($type = 'property') then owl:DatatypeProperty | owl:ObjectProperty else owl:AnnotationProperty)[some $res in rdfs:subPropertyOf/@*:resource satisfies $res = $about]/(@*:about|@*:ID)" />
+        <xsl:variable name="sub-properties" as="attribute()*" select="/rdf:RDF/(if ($type = 'property') then owl:DatatypeProperty | owl:ObjectProperty else owl:AnnotationProperty)[some $res in rdfs:subPropertyOf/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $about]/(@*:about|@*:ID)" />
         <xsl:if test="exists($sub-properties)">
             <dt><xsl:value-of select="f:getDescriptionLabel('hassubproperties')" /></dt>
             <dd>
@@ -1244,16 +1263,16 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     </xsl:template>
     
     <xsl:template name="get.property.domain">
-        <xsl:if test="exists(rdfs:domain)">
+        <xsl:if test="exists((rdfs:domain|schema:domainIncludes))">
             <dt><xsl:value-of select="f:getDescriptionLabel('hasdomain')" /></dt>
-            <xsl:apply-templates select="rdfs:domain" />
+            <xsl:apply-templates select="(rdfs:domain|schema:domainIncludes)" />
         </xsl:if>
     </xsl:template>
     
     <xsl:template name="get.property.range">
-        <xsl:if test="exists(rdfs:range)">
+        <xsl:if test="exists((rdfs:range|schema:rangeIncludes))">
             <dt><xsl:value-of select="f:getDescriptionLabel('hasrange')" /></dt>
-            <xsl:apply-templates select="rdfs:range" />
+            <xsl:apply-templates select="(rdfs:range|schema:rangeIncludes)" />
         </xsl:if>
     </xsl:template>
     
@@ -1387,7 +1406,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <xsl:if test="exists(//owl:Ontology/dc:description[normalize-space() != ''])">
                     <li><a href="#introduction"><xsl:value-of select="f:getDescriptionLabel('introduction')" /></a></li>
                 </xsl:if>
-                <xsl:if test="exists(/rdf:RDF/owl:Class/element())">
+                <xsl:if test="exists(/rdf:RDF/(owl:Class|rdfs:Class)/element())">
                     <li><a href="#classes"><xsl:value-of select="f:getDescriptionLabel('classes')" /></a></li>
                 </xsl:if>
                 <xsl:if test="exists(//owl:ObjectProperty/element())">
@@ -1402,7 +1421,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <xsl:if test="exists(//owl:AnnotationProperty)">
                     <li><a href="#annotationproperties"><xsl:value-of select="f:getDescriptionLabel('annotationproperties')" /></a></li>
                 </xsl:if>
-                <xsl:if test="exists(//rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]) or exists(/rdf:RDF/(owl:Class|owl:Restriction)[empty(@*:about | @*:ID) and exists(rdfs:subClassOf|owl:equivalentClass)])">
+                <xsl:if test="exists(//rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]) or exists(/rdf:RDF/(owl:Class|rdfs:Class|owl:Restriction)[empty(@*:about | @*:ID) and exists(rdfs:subClassOf|owl:equivalentClass)])">
                     <li><a href="#generalaxioms"><xsl:value-of select="f:getDescriptionLabel('generalaxioms')" /></a></li>
                 </xsl:if>
                 <xsl:if test="exists(/rdf:RDF/(swrl:Imp | rdf:Description[rdf:type[@*:resource = 'http://www.w3.org/2003/11/swrl#Imp']]))">
@@ -1422,10 +1441,10 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     </xsl:template>
     
     <xsl:template name="get.generalaxioms">
-        <xsl:if test="exists(/rdf:RDF/rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]) or exists(/rdf:RDF/(owl:Class|owl:Restriction)[empty(@*:ID | @*:about) and exists(rdfs:subClassOf|owl:equivalentClass)])">
+        <xsl:if test="exists(/rdf:RDF/rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]) or exists(/rdf:RDF/(owl:Class|rdfs:Class|owl:Restriction)[empty(@*:ID | @*:about) and exists(rdfs:subClassOf|owl:equivalentClass)])">
             <div id="generalaxioms">
                 <h2><xsl:value-of select="f:getDescriptionLabel('generalaxioms')" /></h2>
-                <xsl:apply-templates select="/rdf:RDF/(rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]|(owl:Class|owl:Restriction)[empty(@*:ID | @*:about) and exists(rdfs:subClassOf|owl:equivalentClass)])" />
+                <xsl:apply-templates select="/rdf:RDF/(rdf:Description[exists(rdf:type[@*:resource = 'http://www.w3.org/2002/07/owl#AllDisjointClasses'])]|(owl:Class|rdfs:Class|owl:Restriction)[empty(@*:ID | @*:about) and exists(rdfs:subClassOf|owl:equivalentClass)])" />
             </div>
         </xsl:if>
     </xsl:template>
@@ -1461,11 +1480,11 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     </xsl:template>
     
     <xsl:template name="get.classes">
-        <xsl:if test="exists(/rdf:RDF/owl:Class/element())">
+        <xsl:if test="exists(/rdf:RDF/(owl:Class|rdfs:Class)/element())">
             <div id="classes">
                 <h2><xsl:value-of select="f:getDescriptionLabel('classes')" /></h2>
                 <xsl:call-template name="get.classes.toc" />
-                <xsl:apply-templates select="/rdf:RDF/owl:Class[exists(element()) and exists(@*:about|@*:ID)]">
+                <xsl:apply-templates select="/rdf:RDF/(owl:Class|rdfs:Class)[exists(element()) and exists(@*:about|@*:ID)]">
                     <xsl:sort select="lower-case(f:getLabel(@*:about|@*:ID))"
                         order="ascending" data-type="text" />
                     <xsl:with-param name="type" tunnel="yes" as="xs:string" select="'class'" />
@@ -1476,7 +1495,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:template name="get.classes.toc">
         <ul class="hlist">
-            <xsl:apply-templates select="/rdf:RDF/owl:Class[exists(element()) and exists(@*:about|@*:ID)]" mode="toc">
+            <xsl:apply-templates select="/rdf:RDF/(owl:Class|rdfs:Class)[exists(element()) and exists(@*:about|@*:ID)]" mode="toc">
                 <xsl:sort select="lower-case(f:getLabel(@*:about|@*:ID))"
                     order="ascending" data-type="text" />
                 <xsl:with-param name="type" tunnel="yes" as="xs:string" select="'class'" />
@@ -1585,7 +1604,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
         <xsl:param name="type" as="xs:string" select="''" tunnel="yes" />
         <xsl:variable name="el" select="$root/rdf:RDF/element()[@*:about = $iri or @*:ID = $iri]" as="element()*" />
         <xsl:choose>
-            <xsl:when test="($type = '' or $type = 'class') and ($el[self::owl:Class] or $iri = 'http://www.w3.org/2002/07/owl#Thing')">
+            <xsl:when test="($type = '' or $type = 'class') and ($el[self::owl:Class] or $el[self::rdfs:Class] or $iri = 'http://www.w3.org/2002/07/owl#Thing')">
                 <sup title="{f:getDescriptionLabel('class')}" class="type-c">c</sup>
             </xsl:when>
             <xsl:when test="($type = '' or $type = 'property') and $el[self::owl:ObjectProperty]">
@@ -1694,7 +1713,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:function name="f:hasSubclasses" as="xs:boolean">
         <xsl:param name="el" as="element()" />
-        <xsl:value-of select="exists($rdf/owl:Class[some $res in rdfs:subClassOf/@*:resource satisfies $res = $el/(@*:about|@*:ID)])" />
+        <xsl:value-of select="exists($rdf/(owl:Class|rdfs:Class)[some $res in rdfs:subClassOf/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $el/(@*:about|@*:ID)])" />
     </xsl:function>
     
     <xsl:function name="f:hasMembers" as="xs:boolean">
@@ -1704,18 +1723,18 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
     
     <xsl:function name="f:isInRange" as="xs:boolean">
         <xsl:param name="el" as="element()" />
-        <xsl:value-of select="exists($rdf/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in rdfs:range/@*:resource satisfies $res = $el/(@*:about|@*:ID)])" />
+        <xsl:value-of select="exists($rdf/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in (rdfs:range|schema:rangeIncludes)/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $el/(@*:about|@*:ID)])" />
     </xsl:function>
     
     <xsl:function name="f:isInDomain" as="xs:boolean">
         <xsl:param name="el" as="element()" />
-        <xsl:value-of select="exists($rdf/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in rdfs:domain/@*:resource satisfies $res = $el/(@*:about|@*:ID)])" />
+        <xsl:value-of select="exists($rdf/(owl:ObjectProperty|owl:DatatypeProperty|owl:AnnotationProperty)[some $res in (rdfs:domain|schema:domainIncludes)/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $el/(@*:about|@*:ID)])" />
     </xsl:function>
     
     <xsl:function name="f:hasSubproperties" as="xs:boolean">
         <xsl:param name="el" as="element()" />
         <xsl:variable name="type" select="if ($el/self::owl:AnnotationProperty) then 'annotation' else 'property'" as="xs:string" />
-        <xsl:value-of select="exists($rdf/(if ($type = 'property') then owl:DatatypeProperty | owl:ObjectProperty else owl:AnnotationProperty)[some $res in rdfs:subPropertyOf/@*:resource satisfies $res = $el/(@*:about|@*:ID)])" />
+        <xsl:value-of select="exists($rdf/(if ($type = 'property') then owl:DatatypeProperty | owl:ObjectProperty else owl:AnnotationProperty)[some $res in rdfs:subPropertyOf/(@*:resource|(owl:Class|rdfs:Class)/@*:about) satisfies $res = $el/(@*:about|@*:ID)])" />
     </xsl:function>
     
     <xsl:function name="f:getType" as="xs:string?">


### PR DESCRIPTION
Fixes https://github.com/essepuntato/LODE/issues/12 (allow schema:domain/rangeIncludes). 
Tested on:
- http://www.essepuntato.it/2008/12/earmark (no change in output)
- http://data.businessgraph.io/ontology (my target)

Also:
- allows rdfs:Class, since many people use that instead of owl:Class.
- allows sub-class and sub-property references using rdf:about instead of rdf:resource, eg (closing tags omitted for brevity)
```rdf
  <owl:ObjectProperty rdf:about="http://data.businessgraph.io/ontology#adminUnitL3">
    <rdfs:subPropertyOf>
      <owl:ObjectProperty rdf:about="http://data.businessgraph.io/ontology#adminUnit"/>
  <rdfs:Class rdf:about="http://data.businessgraph.io/ontology#Register">
    <rdfs:subClassOf>
      <rdfs:Class rdf:about="http://www.w3.org/ns/regorg#RegisteredOrganization"/>
```
Such are produced by some ttl->rdf conversion tools, eg
```sh
riot --output=rdfxml test/ebg-ontology.ttl > test/ebg-ontology.rdf
```